### PR TITLE
Fix bug with lists of leaves

### DIFF
--- a/lib/accent/transformer.ex
+++ b/lib/accent/transformer.ex
@@ -30,7 +30,11 @@ defmodule Accent.Transformer do
   @spec transform(list, Accent.Transformer) :: list
   def transform(list, transformer) do
     for i <- list, into: [] do
-      transform(i, transformer)
+      if is_map(i) || is_list(i) do
+        transform(i, transformer)
+      else
+        i
+      end
     end
   end
 end

--- a/test/accent/transformer_test.exs
+++ b/test/accent/transformer_test.exs
@@ -15,6 +15,8 @@ defmodule Accent.TransformerTest do
     test "property handles arrays" do
       assert Accent.Transformer.transform(%{"helloWorld" => [%{"fooBar" => "value"}]}, Accent.Transformer.SnakeCase)
         == %{"hello_world" => [%{"foo_bar" => "value"}]}
+      assert Accent.Transformer.transform(%{"helloWorld" => ["item"]}, Accent.Transformer.SnakeCase)
+        == %{"hello_world" => ["item"]}
     end
   end
 end


### PR DESCRIPTION
If you have an array of e.g. strings in your JSON response, then the code will try to transform the strings and crash.

This PR fixes this bug.