### PR TITLE
Fix broken is json checks

### DIFF
--- a/lib/accent/plugs/response.ex
+++ b/lib/accent/plugs/response.ex
@@ -62,22 +62,27 @@ defmodule Accent.Plug.Response do
   # private
 
   defp before_send_callback(conn, opts) do
-    is_json_response =
-    conn
-    |> get_req_header("content-type")
-    |> Enum.at(0) || ""
-    |> String.ends_with?("json")
+    response_content_type = 
+      conn
+      |> get_resp_header("content-type")
+      |> Enum.at(0)
+    
+    is_json_response = String.contains?(response_content_type || "", "application/json")
 
-    json_decoder = opts[:json_decoder]
-    json_encoder = opts[:json_encoder]
-
-    resp_body =
-      conn.resp_body
-      |> json_decoder.decode!
-      |> transform(select_transformer(conn, opts))
-      |> json_encoder.encode!
-
-    %{conn | resp_body: resp_body}
+    if is_json_response do
+      json_decoder = opts[:json_decoder]
+      json_encoder = opts[:json_encoder]
+  
+      resp_body =
+        conn.resp_body
+        |> json_decoder.decode!
+        |> transform(select_transformer(conn, opts))
+        |> json_encoder.encode!
+  
+      %{conn | resp_body: resp_body}
+    else
+      conn
+    end 
   end
 
   defp do_call?(conn, opts) do

--- a/lib/accent/plugs/response.ex
+++ b/lib/accent/plugs/response.ex
@@ -62,6 +62,12 @@ defmodule Accent.Plug.Response do
   # private
 
   defp before_send_callback(conn, opts) do
+    is_json_response =
+    conn
+    |> get_req_header("content-type")
+    |> Enum.at(0) || ""
+    |> String.ends_with?("json")
+
     json_decoder = opts[:json_decoder]
     json_encoder = opts[:json_encoder]
 
@@ -75,15 +81,16 @@ defmodule Accent.Plug.Response do
   end
 
   defp do_call?(conn, opts) do
-    is_json =
+    content_type = 
       conn
       |> get_req_header("content-type")
-      |> Enum.at(0) || ""
-      |> String.ends_with?("json")
+      |> Enum.at(0)
+    
+    is_json = String.contains?(content_type || "", "application/json")
 
     has_transformer = select_transformer(conn, opts)
 
-    is_json && has_transformer
+    response = is_json && has_transformer
   end
 
   defp select_transformer(conn, opts) do

--- a/lib/accent/transformer.ex
+++ b/lib/accent/transformer.ex
@@ -30,7 +30,11 @@ defmodule Accent.Transformer do
   @spec transform(list, Accent.Transformer) :: list
   def transform(list, transformer) do
     for i <- list, into: [] do
-      transform(i, transformer)
+      if is_map(i) || is_list(i) do
+        transform(i, transformer)
+      else
+        i
+      end
     end
   end
 end

--- a/test/accent/plugs/response_test.exs
+++ b/test/accent/plugs/response_test.exs
@@ -72,6 +72,17 @@ defmodule Accent.Plug.ResponseTest do
       assert conn.resp_body == "{\"helloWorld\":\"value\"}"
     end
 
+    test "deals with content-type having a charset" do
+      conn =
+        conn(:post, "/")
+        |> put_req_header("accent", "pascal")
+        |> put_req_header("content-type", "application/json; charset=utf-8")
+        |> Accent.Plug.Response.call(@opts)
+        |> Plug.Conn.send_resp(200, "{\"hello_world\":\"value\"}")
+
+      assert conn.resp_body == "{\"helloWorld\":\"value\"}"
+    end
+
     test "skips conversion if no header is provided" do
       conn =
         conn(:post, "/")
@@ -85,6 +96,7 @@ defmodule Accent.Plug.ResponseTest do
     test "skips conversion if content type is not JSON" do
       conn =
         conn(:post, "/")
+        |> put_req_header("accent", "pascal")
         |> put_req_header("content-type", "application/something")
         |> Accent.Plug.Response.call(@opts)
         |> Plug.Conn.send_resp(200, "{\"hello_world\":\"value\"}")

--- a/test/accent/transformer_test.exs
+++ b/test/accent/transformer_test.exs
@@ -15,6 +15,8 @@ defmodule Accent.TransformerTest do
     test "property handles arrays" do
       assert Accent.Transformer.transform(%{"helloWorld" => [%{"fooBar" => "value"}]}, Accent.Transformer.SnakeCase)
         == %{"hello_world" => [%{"foo_bar" => "value"}]}
+      assert Accent.Transformer.transform(%{"helloWorld" => ["item"]}, Accent.Transformer.SnakeCase)
+        == %{"hello_world" => ["item"]}
     end
   end
 end


### PR DESCRIPTION
The current calculation for is_json always returns the actual content-type string due to the || operator in the pipeline. The test for this was also broken (no Accent header was provided). I fixed the test and the code.

I also changed the callback to only try and parse a response that is JSON. Otherwise if you run into an error whilst in the Phoenix development environment, it will try to return a nicely formatted HTML page which will promptly crash the callback which expects a JSON object.